### PR TITLE
chore: moving to 26.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -139,16 +139,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1778905220,
-        "narHash": "sha256-ox/5IHc8uwy6UTw6N7Shp6uCHIgu/S2PsWeuXsOHSo8=",
+        "lastModified": 1780883961,
+        "narHash": "sha256-WU6SUrESuPiEXEUvX4D51AgWrXRJty+sLJBwBaDBGqE=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "d1686dc7d36cbd1234cb226ad6ef97e882716acb",
+        "rev": "4eb4fec41674d5b059aa2eedf0f98453890546fa",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "home-manager",
         "type": "github"
       }
@@ -201,16 +201,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1772129556,
-        "narHash": "sha256-Utk0zd8STPsUJPyjabhzPc5BpPodLTXrwkpXBHYnpeg=",
+        "lastModified": 1780789116,
+        "narHash": "sha256-+/LcDMJGYQVLp3ECZ1jBhj3GcQU+Yt+OTsDsQFz8cMs=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "ebec37af18215214173c98cf6356d0aca24a2585",
+        "rev": "731951a251ca96cbd12a8e1bde63737e21947644",
         "type": "github"
       },
       "original": {
         "owner": "nix-darwin",
-        "ref": "nix-darwin-25.11",
+        "ref": "nix-darwin-26.05",
         "repo": "nix-darwin",
         "type": "github"
       }
@@ -402,16 +402,16 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1778737229,
-        "narHash": "sha256-6xWoytx8jFW4PF1GjRm/i/53trbpKGfz6zjzQGBr4cI=",
+        "lastModified": 1780734595,
+        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d7a713c0b7e47c908258e71cba7a2d77cc8d71d5",
+        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,21 +2,24 @@
   description = "Hayao Nix Dotfiles";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable";
 
     # IPU7 camera support (PR #479283) - remove once merged into nixpkgs
     nixpkgs-ipu7.url = "github:NixOS/nixpkgs/pull/479283/head";
 
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin/nix-darwin-25.11";
+      url = "github:nix-darwin/nix-darwin/nix-darwin-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-25.11";
+      url = "github:nix-community/home-manager/release-26.05";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    # Better flake management
+    flake-parts.url = "github:hercules-ci/flake-parts";
 
     llm-agents.url = "github:numtide/llm-agents.nix";
 
@@ -34,9 +37,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.home-manager.follows = "home-manager";
     };
-
-    # Better flake management
-    flake-parts.url = "github:hercules-ci/flake-parts";
   };
 
   outputs =
@@ -89,14 +89,13 @@
         ];
         perSystem =
           {
-            config,
             pkgs,
             system,
             ...
           }:
           {
             # Formatter for your nix files, available through 'nix fmt'
-            formatter = pkgs.nixfmt-tree;
+            formatter = pkgs.nixfmt-rs;
 
             # Packages
             packages = import ./pkgs {

--- a/modules/home-manager/git/default.nix
+++ b/modules/home-manager/git/default.nix
@@ -9,7 +9,7 @@
     git = {
       isMacOS = lib.mkOption {
         type = lib.types.bool;
-        default = pkgs.hostPlatform.isDarwin;
+        default = pkgs.stdenv.hostPlatform.isDarwin;
         description = "Install MacOS specific agent.";
       };
     };

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -10,7 +10,7 @@
   # Claude Code
   programs.claude-code = {
     enable = true;
-    package = inputs.llm-agents.packages.${pkgs.system}.claude-code;
+    package = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
     settings = {
       autoUpdater = {
         disabled = true;
@@ -140,7 +140,7 @@
 
   # LLM-related packages
   home.packages = [
-    inputs.llm-agents.packages.${pkgs.system}.ccstatusline
+    inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.ccstatusline
     pkgs.gemini-cli
   ];
 }

--- a/modules/home-manager/llm/default.nix
+++ b/modules/home-manager/llm/default.nix
@@ -25,7 +25,7 @@
         defaultMode = "auto";
       };
     };
-    memory.text = ''
+    context = ''
       # Commit Rules
 
       - コミット作成時に `Co-Authored-By` ヘッダーを絶対に追加しないこと。Claude Code やその他の AI をco-authorとして記載することを禁止する。コミットメッセージには `Co-Authored-By` 行を一切含めないこと。

--- a/modules/home-manager/pkgs/global.nix
+++ b/modules/home-manager/pkgs/global.nix
@@ -37,7 +37,6 @@
   # pkgs.hello
   # pkgs.roulette
 
-  pkgs.nil
-  pkgs.nixfmt-rfc-style
-  pkgs.nixfmt-tree
+  pkgs.nixd
+  pkgs.nixfmt-rs
 ]

--- a/modules/home-manager/theme/default.nix
+++ b/modules/home-manager/theme/default.nix
@@ -53,6 +53,7 @@ in
     };
 
     # GTK4 settings
+    gtk4.theme = config.gtk.theme;
     gtk4.extraConfig = {
       gtk-application-prefer-dark-theme = true;
     };

--- a/modules/home-manager/xdg/default.nix
+++ b/modules/home-manager/xdg/default.nix
@@ -12,6 +12,7 @@ in
     userDirs = {
       enable = true;
       createDirectories = true;
+      setSessionVariables = true;
       desktop = "${homeDir}/Desktop";
       documents = "${homeDir}/Documents";
       download = "${homeDir}/Downloads";

--- a/modules/home-manager/zsh/default.nix
+++ b/modules/home-manager/zsh/default.nix
@@ -1,4 +1,4 @@
-{ ... }:
+{ config, ... }:
 {
 
   imports = [
@@ -11,6 +11,8 @@
   programs.zsh = {
     # Install zsh
     enable = true;
+
+    dotDir = config.home.homeDirectory;
 
     # ZSH Autosuggestions
     # The option `programs.zsh.enableAutosuggestions' defined in config

--- a/modules/nixos/user/apps/default.nix
+++ b/modules/nixos/user/apps/default.nix
@@ -98,7 +98,8 @@ in
           mission-center # System monitor like Windows Task Manager
           gparted
           baobab # GNOME disk usage analyzer
-          globalprotect-openconnect # GlobalProtect VPN client with GUI
+          # @orzklv: error: 'globalprotect-openconnect' was removed because it was unmaintained in Nixpkgs and needed upgrading to the Tauri rewrite, as the old version depends on the removed Qt 5 WebEngine
+          # globalprotect-openconnect # GlobalProtect VPN client with GUI
         ]
       )
       ++ lib.optionals cfg.office (

--- a/shell.nix
+++ b/shell.nix
@@ -23,11 +23,10 @@
 pkgs.mkShell {
   packages = with pkgs; [
     # Nix related
-    nil # old lsp
     nixd # better lsp
-    nixfmt # formatter
     statix # lint
     deadnix # dead code check
+    nixfmt-rs # formatter
 
     # Utilities
     git


### PR DESCRIPTION
I attempted to upgrade your configurations to 26.05. If you were planning to do it yourself, close this PR and proceed to do it on your own, feel free to use this as guide or reference. There are anyways things that require attention even after merge:

<img width="1588" height="973" alt="Skrinshot: 2026-06-08 09-34-25" src="https://github.com/user-attachments/assets/36732505-8990-40c0-9e97-e5d45b88e9a5" />
